### PR TITLE
feat: Add install metamask guide state for login modal

### DIFF
--- a/src/components/SignInModal/index.tsx
+++ b/src/components/SignInModal/index.tsx
@@ -7,12 +7,15 @@ import {
   ModalBody,
   ModalCloseButton,
   Text,
+  IconButton,
 } from '@chakra-ui/react'
+import { ArrowBackIcon } from '@chakra-ui/icons'
 import { useState } from 'react'
 
 import MetaMaskCard from '../../components/connectors/MetaMaskCard'
 import MagicCard from '../../components/connectors/MagicCard'
 import useAuth from '../../hooks/useAuth'
+import InstallMetaMaskGuideSection from '../sections/InstallMetaMaskGuide'
 
 enum Connector {
   MetaMask = 'MetaMask',
@@ -32,30 +35,60 @@ const CONTENT = {
   },
 }
 
-function SignInModal() {
+const BackButton = ({ onClick }: { onClick: () => void }) => (
+  <IconButton
+    aria-label="Back to choose the login method"
+    bgColor="transparent"
+    fontSize="22px"
+    h="24px"
+    icon={<ArrowBackIcon color="brand.700" opacity={0.8} />}
+    left={3}
+    onClick={onClick}
+    top={3}
+    w="24px"
+  />
+)
+
+const SignInModal = () => {
   const { isSignInModalOpen, onSignInModalClose } = useAuth()
   const [connector, setConnector] = useState(Connector.MetaMask)
+  const [showInstallMetaMaskGuide, setShowInstallMetaMaskGuide] = useState(false)
 
   return (
     <Modal isCentered isOpen={isSignInModalOpen} onClose={onSignInModalClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{CONTENT[connector].title}</ModalHeader>
+        {showInstallMetaMaskGuide && (
+          <BackButton onClick={() => setShowInstallMetaMaskGuide(false)} />
+        )}
         <ModalCloseButton />
-        <ModalBody>
-          <Text variant="modalDescription">{CONTENT[connector].description}</Text>
-          {connector === Connector.MetaMask ? <MetaMaskCard /> : <MagicCard />}
-          <Button
-            _focus={{ outline: 'none' }}
-            isFullWidth
-            onClick={() =>
-              setConnector(connector === Connector.MetaMask ? Connector.Magic : Connector.MetaMask)
-            }
-            variant="ghost"
-          >
-            {CONTENT[connector].footerButtonLabel}
-          </Button>
-        </ModalBody>
+        {showInstallMetaMaskGuide ? (
+          <InstallMetaMaskGuideSection />
+        ) : (
+          <>
+            <ModalHeader>{CONTENT[connector].title}</ModalHeader>
+            <ModalBody>
+              <Text variant="modalDescription">{CONTENT[connector].description}</Text>
+              {connector === Connector.MetaMask ? (
+                <MetaMaskCard setShowInstallMetaMaskGuide={setShowInstallMetaMaskGuide} />
+              ) : (
+                <MagicCard />
+              )}
+              <Button
+                _focus={{ outline: 'none' }}
+                isFullWidth
+                onClick={() =>
+                  setConnector(
+                    connector === Connector.MetaMask ? Connector.Magic : Connector.MetaMask,
+                  )
+                }
+                variant="ghost"
+              >
+                {CONTENT[connector].footerButtonLabel}
+              </Button>
+            </ModalBody>
+          </>
+        )}
       </ModalContent>
     </Modal>
   )

--- a/src/components/connectors/MetaMaskCard.tsx
+++ b/src/components/connectors/MetaMaskCard.tsx
@@ -9,13 +9,22 @@ import ErrorSection from './ErrorSection'
 
 const { useIsActive, useError, useIsActivating } = hooks
 
-export default function MetaMaskCard() {
+export default function MetaMaskCard({
+  setShowInstallMetaMaskGuide,
+}: {
+  setShowInstallMetaMaskGuide: (show: boolean) => void
+}) {
   const { user } = useAuth()
   const isMMActive = useIsActive()
   const isActivating = useIsActivating()
   const error = useError()
+  const hasMetaMaskInstalled = !!window.ethereum
 
   const onClick = async () => {
+    if (!hasMetaMaskInstalled) {
+      setShowInstallMetaMaskGuide(true)
+      return
+    }
     if (!isMMActive) {
       await metaMask.activate(getAddChainParameters(chainId))
     }

--- a/src/components/sections/InstallMetaMaskGuide.tsx
+++ b/src/components/sections/InstallMetaMaskGuide.tsx
@@ -1,0 +1,40 @@
+import { Button, Flex, Text } from '@chakra-ui/react'
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+
+const InstallMetaMaskGuideSection = () => {
+  return (
+    <Flex align="center" flexDir="column" justify="center">
+      <Text variant="modalTitle">HAVE YOU INSTALLED METAMASK?</Text>
+      <Text variant="modalDescription" fontSize={16}>
+        To play ZED you need to have an ethereum wallet. We&aposve detected that your browser does
+        not have Metamask installed. Metamask is widely used by many blockchain applications in
+        order to keep your information secure.
+      </Text>
+      <Text mt="32px" variant="modalDescription">
+        What is MetaMask? Head over to our
+        <Text
+          as="span"
+          color="green.900"
+          ml={1}
+          onClick={() =>
+            window.open('https://community.zed.run/2021/09/10/zed-run-guide/', '_blank')
+          }
+          _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
+        >
+          FAQ
+        </Text>
+      </Text>
+      <Button
+        mb="16px"
+        mt="8px"
+        rightIcon={<ExternalLinkIcon fontSize="24px" />}
+        onClick={() => window.open('https://metamask.io/', '_blank')}
+        variant="primary"
+      >
+        Install Metamask
+      </Button>
+    </Flex>
+  )
+}
+
+export default InstallMetaMaskGuideSection

--- a/src/components/sections/InstallMetaMaskGuide.tsx
+++ b/src/components/sections/InstallMetaMaskGuide.tsx
@@ -1,21 +1,25 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable react/no-unescaped-entities */
 import { Button, Flex, Text } from '@chakra-ui/react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
 
 const InstallMetaMaskGuideSection = () => {
   return (
-    <Flex align="center" flexDir="column" justify="center">
-      <Text variant="modalTitle">HAVE YOU INSTALLED METAMASK?</Text>
-      <Text variant="modalDescription" fontSize={16}>
-        To play ZED you need to have an ethereum wallet. We&aposve detected that your browser does
-        not have Metamask installed. Metamask is widely used by many blockchain applications in
-        order to keep your information secure.
+    <Flex align="center" flexDir="column" justify="center" px="16px" py="32px">
+      <Text mt="16px" variant="modalTitle">
+        HAVE YOU INSTALLED METAMASK?
       </Text>
-      <Text mt="32px" variant="modalDescription">
+      <Text variant="modalDescription" fontSize={16} lineHeight="24px" my="24px">
+        To play ZED you need to have an ethereum wallet. We've detected that your browser does not
+        have Metamask installed. Metamask is widely used by many blockchain applications in order to
+        keep your information secure.
+      </Text>
+      <Text fontSize="14px" variant="modalDescription">
         What is MetaMask? Head over to our
         <Text
           as="span"
           color="green.900"
-          ml={1}
+          ml="4px"
           onClick={() =>
             window.open('https://community.zed.run/2021/09/10/zed-run-guide/', '_blank')
           }
@@ -26,7 +30,7 @@ const InstallMetaMaskGuideSection = () => {
       </Text>
       <Button
         mb="16px"
-        mt="8px"
+        mt="16px"
         rightIcon={<ExternalLinkIcon fontSize="24px" />}
         onClick={() => window.open('https://metamask.io/', '_blank')}
         variant="primary"

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -11,6 +11,9 @@ const colors = {
     900: '#27B18A',
     800: '#2ECCA0',
   },
+  greenAlpha: {
+    900: 'rgba(39, 177, 138, 0.32)',
+  },
 }
 
 const fonts = {
@@ -27,6 +30,28 @@ const config = {
 const components = {
   Button: {
     variants: {
+      primary: {
+        color: colors.brand[700],
+        background: `linear-gradient(90deg, ${colors.green[800]} 0%, ${colors.green[900]} 100%)`,
+        boxShadow: `0px 0px 8px ${colors.greenAlpha[900]}`,
+        borderRadius: '8px',
+        fontSize: '16px',
+        letterSpacing: '0.0666667px',
+        lineHeight: '24px',
+        p: '24px',
+        textAlign: 'center',
+        transition: '0.5s',
+        _hover: {
+          background: `linear-gradient(90deg, ${colors.green[800]} 0%, ${colors.green[900]} 100%)`,
+          boxShadow: `0px 0px 8px ${colors.greenAlpha[900]}`,
+          opacity: 0.85,
+        },
+        _disabled: {
+          background: 'rgba(240, 248, 255, 0.24)',
+          color: 'rgba(240, 248, 255, 0.24)',
+          opacity: 1,
+        },
+      },
       ghost: {
         color: 'green.900',
         fontWeight: '700',
@@ -72,6 +97,14 @@ const components = {
         lineHeight: 4,
         mb: 4,
         opacity: 0.64,
+        textAlign: 'center',
+      },
+      modalTitle: {
+        color: 'brand.700',
+        fontSize: [22, 25],
+        fontWeight: '700',
+        letterSpacing: 0.2475,
+        lineHeight: 8,
         textAlign: 'center',
       },
     },


### PR DESCRIPTION
# Description

## 🎫 **Ticket:**

- [OA-1122](https://linear.app/vhslab/issue/OA-1122/[task]-implement-login-modal)

## ⛑️ **What was done:**

Implement `Install MetaMask guide` state for Login Modal component

## Type of change

Please delete options that are not relevant.

- [x] New feature 

### 🧪 **How to test:**

1. Enter in some browser/session that does not have MetaMask installed
2. On the main page, click on `Sign In`
3. Then, click on the MetaMask option when you open the modal
4. You should be able to see the content of the image below in this PR

### 🗒️ **Notes:**

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### 🖼️ **Screenshots:**
![1](https://user-images.githubusercontent.com/103451615/163640241-78616f11-f9c0-4d32-8ed6-fb33ef5c8e9d.PNG)

